### PR TITLE
port as number; console.log -> process.stdout.write

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -23,18 +23,18 @@ function start () {
   startup.create('stop-server', process.execPath, [__dirname], log)
 
   if (os.platform() !== 'win32') {
-    console.log(
+    process.stdout.write(
       [
         '',
         '---',
         'To complete installation, you need to allow \'shutdown\' to be run without sudo.',
         'Please run ' + chalk.cyan('sudo visudo') + ' and add ' + chalk.cyan('your-username ALL=NOPASSWD: /sbin/shutdown'),
         '---'
-      ].join('\n')
+      ].join('\n') + '\n'
     )
   }
 
-  console.log(
+  process.stdout.write(
     [
       '',
       'To access stop-server from your phone, scan the QR code here',
@@ -43,7 +43,7 @@ function start () {
       'Or go directly to',
       chalk.cyan('http://' + address() + ':5709'),
       ''
-    ].join('\n')
+    ].join('\n') + '\n'
   )
 }
 
@@ -58,4 +58,4 @@ var argv = yargs.argv
 if (argv._[0] === 'start') return start()
 if (argv._[0] === 'stop') return stop()
 
-console.log(yargs.showHelp)
+process.stdout.write(yargs.showHelp)

--- a/bin.js
+++ b/bin.js
@@ -23,18 +23,18 @@ function start () {
   startup.create('stop-server', process.execPath, [__dirname], log)
 
   if (os.platform() !== 'win32') {
-    process.stdout.write(
+    console.log(
       [
         '',
         '---',
         'To complete installation, you need to allow \'shutdown\' to be run without sudo.',
         'Please run ' + chalk.cyan('sudo visudo') + ' and add ' + chalk.cyan('your-username ALL=NOPASSWD: /sbin/shutdown'),
         '---'
-      ].join('\n') + '\n'
+      ].join('\n')
     )
   }
 
-  process.stdout.write(
+  console.log(
     [
       '',
       'To access stop-server from your phone, scan the QR code here',
@@ -43,7 +43,7 @@ function start () {
       'Or go directly to',
       chalk.cyan('http://' + address() + ':5709'),
       ''
-    ].join('\n') + '\n'
+    ].join('\n')
   )
 }
 
@@ -58,4 +58,4 @@ var argv = yargs.argv
 if (argv._[0] === 'start') return start()
 if (argv._[0] === 'stop') return stop()
 
-process.stdout.write(yargs.showHelp)
+console.log(yargs.showHelp)

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ app.get('/update', function (req, res) {
   })
 })
 
-var port = '5709'
+var port = 5709
 
 app.listen(port, function () {
   util.log('stop-server listening on port ' + port)


### PR DESCRIPTION
Even though passing a `String` to `app.listen` works, it's seems more intuitive to read the port as a number.

`process.stdout.write`, in opposition to `console.log`, does not try to interpret the argument passed. Also it is more readable.

Great package btw! :sparkles: 
